### PR TITLE
Fix deprecated MaxCDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ goldmark-emoji
 [godev-image]: https://pkg.go.dev/badge/github.com/yuin/goldmark-emoji
 [godev-url]: https://pkg.go.dev/github.com/yuin/goldmark-emoji
 
-goldmark-emoji is an extension for the [goldmark](http://github.com/yuin/goldmark) 
+goldmark-emoji is an extension for the [goldmark](http://github.com/yuin/goldmark)
 that parses `:joy:` style emojis.
 
 Installation
 --------------------
 
-```
+```sh
 go get github.com/yuin/goldmark-emoji
 ```
 
@@ -59,13 +59,12 @@ Options for the extension
 | `WithTwemojiTemplate` | Twemoji img tag printf template |
 | `WithRendererFunc` | renders by a go function |
 
-
-
 License
 --------------------
+
 MIT
 
 Author
 --------------------
-Yusuke Inuzuka
 
+Yusuke Inuzuka

--- a/emoji.go
+++ b/emoji.go
@@ -109,7 +109,7 @@ type RendererConfig struct {
 }
 
 // DefaultTwemojiTemplate is a default value for RendererConfig.TwemojiTemplate.
-const DefaultTwemojiTemplate = `<img class="emoji" draggable="false" alt="%[1]s" src="https://twemoji.maxcdn.com/v/latest/72x72/%[2]s.png"%[3]s>`
+const DefaultTwemojiTemplate = `<img class="emoji" draggable="false" alt="%[1]s" src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/72x72/%[2]s.png"%[3]s>`
 
 // SetOption implements renderer.SetOptioner.
 func (c *RendererConfig) SetOption(name renderer.OptionName, value interface{}) {

--- a/emoji_test.go
+++ b/emoji_test.go
@@ -49,7 +49,7 @@ func TestOptions(t *testing.T) {
 		Lucky :joy:
 		`),
 		Expected: strings.TrimSpace(`
-		<p>Lucky <img class="emoji" draggable="false" alt="face with tears of joy" src="https://twemoji.maxcdn.com/v/latest/72x72/1f602.png"></p>
+		<p>Lucky <img class="emoji" draggable="false" alt="face with tears of joy" src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/72x72/1f602.png"></p>
 		`),
 	}, t)
 
@@ -72,7 +72,7 @@ func TestOptions(t *testing.T) {
 		Lucky :joy:
 		`),
 		Expected: strings.TrimSpace(`
-		<p>Lucky <img class="emoji" draggable="false" alt="face with tears of joy" src="https://twemoji.maxcdn.com/v/latest/72x72/1f602.png" /></p>
+		<p>Lucky <img class="emoji" draggable="false" alt="face with tears of joy" src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/72x72/1f602.png" /></p>
 		`),
 	}, t)
 
@@ -80,7 +80,7 @@ func TestOptions(t *testing.T) {
 		goldmark.WithExtensions(
 			New(
 				WithRenderingMethod(Twemoji),
-				WithTwemojiTemplate(`<img class="myclass" draggable="false" alt="%[1]s" src="https://twemoji.maxcdn.com/v/latest/36x36/%[2]s.png"%[3]s>`),
+				WithTwemojiTemplate(`<img class="myclass" draggable="false" alt="%[1]s" src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/36x36/%[2]s.png"%[3]s>`),
 			),
 		),
 	)
@@ -93,7 +93,7 @@ func TestOptions(t *testing.T) {
 		Lucky :joy:
 		`),
 		Expected: strings.TrimSpace(`
-        <p>Lucky <img class="myclass" draggable="false" alt="face with tears of joy" src="https://twemoji.maxcdn.com/v/latest/36x36/1f602.png"></p>
+        <p>Lucky <img class="myclass" draggable="false" alt="face with tears of joy" src="https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/36x36/1f602.png"></p>
 		`),
 	}, t)
 


### PR DESCRIPTION
MaxCDN seems to have [shut down](https://github.com/twitter/twemoji/issues/580) and no longer works for loading Tweomoji from. I replaced the links to MaxCDN with links to [jsDelivr's](https://www.jsdelivr.com/package/npm/twemoji) CDN. 

All tests pass:
![image](https://github.com/user-attachments/assets/ae65f1d5-20c3-4ce4-94a7-07b55bf7e72e)
